### PR TITLE
リサイズ時の補完方式変更

### DIFF
--- a/lib/utility/multipart_file_helper.dart
+++ b/lib/utility/multipart_file_helper.dart
@@ -123,8 +123,8 @@ class MultipartFileHelper {
       if (decoded.width > maxSize || decoded.height > maxSize) {
         // 横長画像
         resized = decoded.width > decoded.height //
-            ? image.copyResize(decoded, width: maxSize, interpolation: image.Interpolation.cubic) // 横長なのでwidthを揃える
-            : image.copyResize(decoded, height: maxSize, interpolation: image.Interpolation.cubic); // 縦長なのでheightを揃える
+            ? image.copyResize(decoded, width: maxSize, interpolation: image.Interpolation.linear) // 横長なのでwidthを揃える
+            : image.copyResize(decoded, height: maxSize, interpolation: image.Interpolation.linear); // 縦長なのでheightを揃える
 
         resizeDone = true;
       } else {
@@ -140,7 +140,6 @@ class MultipartFileHelper {
       // Note: bakeOrientation内で行われているexifデータの削除は効果がないので別途削除する
       // Note: bakeOrientation内ではexif.dataを削除しているが、encodeメソッドはexif.rawDataを参照している
       final baked = image.bakeOrientation(resized); //
-
 
       return baked;
     };


### PR DESCRIPTION
- リサイズするときにぼやけてしまう問題があったので、リサイズの補完方式をcubic->linear

before after
<img src="https://github.com/toridori-inc/collabo_marketing_app/assets/10914919/9e01312a-cc5c-414a-8477-d4a0b6bb5f59" width="50%" /><img src="https://github.com/toridori-inc/collabo_marketing_app/assets/10914919/c832c983-8b41-4a4c-a52f-d678b0515dab" width="50%" />